### PR TITLE
Fix bug in GetShipmentTrackerAsync

### DIFF
--- a/Nop.Plugin.Shipping.AustraliaPost/AustraliaPostComputationMethod.cs
+++ b/Nop.Plugin.Shipping.AustraliaPost/AustraliaPostComputationMethod.cs
@@ -375,7 +375,7 @@ namespace Nop.Plugin.Shipping.AustraliaPost
         /// </summary>
         public Task<IShipmentTracker> GetShipmentTrackerAsync()
         {
-            return null;
+            return Task.FromResult<IShipmentTracker>(null);
         }
 
         #endregion


### PR DESCRIPTION
GetShipmentTrackerAsync() throws an error when called from MessageTokenProvider.cs AddShipmentTokensAsync